### PR TITLE
Use a longer timeout in case of DNS lookup

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -110,7 +110,7 @@ nsapi_error_t ISM43362Interface::gethostbyname(const char *name, SocketAddress *
     
     char *ipbuff = new char[NSAPI_IP_SIZE];
     int ret = 0;
-    
+    _ism.setTimeout(ISM43362_CONNECT_TIMEOUT);
     if(!_ism.dns_lookup(name, ipbuff)) {
         ret = NSAPI_ERROR_DEVICE_ERROR;
     } else {


### PR DESCRIPTION
In case of DNS lookup, use the CONNECT timeout as (currently 15sec),
to avoid returning a timeout too early.