### PR TITLE
Programmable security level for network AP connection

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -177,7 +177,7 @@ bool ISM43362::dhcp(bool enabled)
     return (_parser.send("C4=%d", enabled ? 1:0) && check_response());
 }
 
-bool ISM43362::connect(const char *ap, const char *passPhrase)
+bool ISM43362::connect(const char *ap, const char *passPhrase, uint32_t ap_sec)
 {
     if (!(_parser.send("C1=%s", ap) && check_response())) {
         return false;
@@ -186,8 +186,12 @@ bool ISM43362::connect(const char *ap, const char *passPhrase)
     if (!(_parser.send("C2=%s", passPhrase) && check_response())) {
         return false;
     }
-    /* TODO security level = 3 , is it hardcoded or not ???? */
-    if (!(_parser.send("C3=3") && check_response())) {
+
+    /* Check security level is acceptable */
+    if (ap_sec > 5) {
+        return false;
+    }
+    if (!(_parser.send("C3=%d", ap_sec) && check_response())) {
         return false;
     }
     /* now connect */

--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -177,7 +177,7 @@ bool ISM43362::dhcp(bool enabled)
     return (_parser.send("C4=%d", enabled ? 1:0) && check_response());
 }
 
-bool ISM43362::connect(const char *ap, const char *passPhrase, uint32_t ap_sec)
+bool ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_sec)
 {
     if (!(_parser.send("C1=%s", ap) && check_response())) {
         return false;
@@ -188,9 +188,11 @@ bool ISM43362::connect(const char *ap, const char *passPhrase, uint32_t ap_sec)
     }
 
     /* Check security level is acceptable */
-    if (ap_sec > 5) {
+    if (ap_sec > ISM_SECURITY_WPA_WPA2 ) {
+        debug_if(ism_debug, "Unsupported security level %d\n", ap_sec);
         return false;
     }
+
     if (!(_parser.send("C3=%d", ap_sec) && check_response())) {
         return false;
     }

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -32,6 +32,14 @@
 #define ES_WIFI_MAX_RX_PACKET_SIZE                     1200
 // Module maxume DATA payload for Tx packet is 1460
 #define ES_WIFI_MAX_TX_PACKET_SIZE                     1460
+typedef enum ism_security {
+    ISM_SECURITY_NONE         = 0x0,      /*!< open access point */
+    ISM_SECURITY_WEP          = 0x1,      /*!< phrase conforms to WEP */
+    ISM_SECURITY_WPA          = 0x2,      /*!< phrase conforms to WPA */
+    ISM_SECURITY_WPA2         = 0x3,      /*!< phrase conforms to WPA2 */
+    ISM_SECURITY_WPA_WPA2     = 0x4,      /*!< phrase conforms to WPA/WPA2 */
+    ISM_SECURITY_UNKNOWN      = 0xFF,     /*!< unknown/unsupported security in scan results */
+} ism_security_t;
 
 /** ISM43362Interface class.
     This is an interface to a ISM43362 radio.
@@ -71,7 +79,7 @@ public:
     * @param ap_sec the security level of network AP
     * @return true only if ISM43362 is connected successfully
     */
-    bool connect(const char *ap, const char *passPhrase, uint32_t ap_sec);
+    bool connect(const char *ap, const char *passPhrase, ism_security_t ap_sec);
 
     /**
     * Disconnect ISM43362 from AP

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -28,7 +28,7 @@
 #define ES_WIFI_RTOS_REV_SIZE                       16
 
 // The input range for AT Command 'R1' is 0 to 1200 bytes
-// ‘R1’ Set Read Transport Packet Size (bytes)
+// 'R1' Set Read Transport Packet Size (bytes)
 #define ES_WIFI_MAX_RX_PACKET_SIZE                     1200
 // Module maxume DATA payload for Tx packet is 1460
 #define ES_WIFI_MAX_TX_PACKET_SIZE                     1460
@@ -68,9 +68,10 @@ public:
     *
     * @param ap the name of the AP
     * @param passPhrase the password of AP
+    * @param ap_sec the security level of network AP
     * @return true only if ISM43362 is connected successfully
     */
-    bool connect(const char *ap, const char *passPhrase);
+    bool connect(const char *ap, const char *passPhrase, uint32_t ap_sec);
 
     /**
     * Disconnect ISM43362 from AP

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -85,7 +85,7 @@ int ISM43362Interface::connect()
 
     _ism.setTimeout(ISM43362_CONNECT_TIMEOUT);
 
-    if (!_ism.connect(ap_ssid, ap_pass, (uint32_t)ap_sec)) {
+    if (!_ism.connect(ap_ssid, ap_pass, ap_sec)) {
         return NSAPI_ERROR_NO_CONNECTION;
     }
 
@@ -136,7 +136,26 @@ int ISM43362Interface::set_credentials(const char *ssid, const char *pass, nsapi
     memset(ap_pass, 0, sizeof(ap_pass));
     strncpy(ap_pass, pass, sizeof(ap_pass));
 
-    ap_sec = security;
+    switch(security) {
+        case NSAPI_SECURITY_NONE:
+            ap_sec = ISM_SECURITY_NONE;
+            break;
+        case NSAPI_SECURITY_WEP:
+            ap_sec = ISM_SECURITY_WEP;
+            break;
+        case NSAPI_SECURITY_WPA:
+            ap_sec = ISM_SECURITY_WPA;
+            break;
+        case NSAPI_SECURITY_WPA2:
+            ap_sec = ISM_SECURITY_WPA2;
+            break;
+        case NSAPI_SECURITY_WPA_WPA2:
+            ap_sec = ISM_SECURITY_WPA_WPA2;
+            break;
+        default:
+            ap_sec = ISM_SECURITY_UNKNOWN;
+            break;
+    }
     _mutex.unlock();
 
     return 0;

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -85,7 +85,7 @@ int ISM43362Interface::connect()
 
     _ism.setTimeout(ISM43362_CONNECT_TIMEOUT);
 
-    if (!_ism.connect(ap_ssid, ap_pass)) {
+    if (!_ism.connect(ap_ssid, ap_pass, (uint32_t)ap_sec)) {
         return NSAPI_ERROR_NO_CONNECTION;
     }
 

--- a/ISM43362Interface.h
+++ b/ISM43362Interface.h
@@ -278,7 +278,7 @@ private:
     Mutex _mutex;
     Thread thread_read_socket;
     char ap_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
-    nsapi_security_t ap_sec;
+    ism_security_t ap_sec;
     uint8_t ap_ch;
     char ap_pass[64]; /* The longest allowed passphrase */
 


### PR DESCRIPTION
As discussed in #3 the security level is hardcoded in the driver.
This PR allows to pass the network AP security level as a parameter of the connect function

@LMESTM @jononi
