### PR TITLE
WPA2 security level cannot be read in scan function

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -322,6 +322,7 @@ extern "C" nsapi_security_t ParseSecurity(char* ptr)
   else if(strstr(ptr,"WPA2 AES")) return NSAPI_SECURITY_WPA2; 
   else if(strstr(ptr,"WPA WPA2")) return NSAPI_SECURITY_WPA_WPA2; 
   else if(strstr(ptr,"WPA2 TKIP")) return NSAPI_SECURITY_UNKNOWN; // no match in mbed
+  else if(strstr(ptr,"WPA2")) return NSAPI_SECURITY_WPA2; // catch any other WPA2 formula
   else if(strstr(ptr,"WPA")) return NSAPI_SECURITY_WPA;
   else return NSAPI_SECURITY_UNKNOWN;
 }

--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -319,11 +319,11 @@ extern "C" nsapi_security_t ParseSecurity(char* ptr)
 {
   if(strstr(ptr,"Open")) return NSAPI_SECURITY_NONE;
   else if(strstr(ptr,"WEP")) return NSAPI_SECURITY_WEP;
-  else if(strstr(ptr,"WPA")) return NSAPI_SECURITY_WPA;   
   else if(strstr(ptr,"WPA2 AES")) return NSAPI_SECURITY_WPA2; 
   else if(strstr(ptr,"WPA WPA2")) return NSAPI_SECURITY_WPA_WPA2; 
-  else if(strstr(ptr,"WPA2 TKIP")) return NSAPI_SECURITY_UNKNOWN; // ?? no match in mbed ?   
-  else return NSAPI_SECURITY_UNKNOWN;           
+  else if(strstr(ptr,"WPA2 TKIP")) return NSAPI_SECURITY_UNKNOWN; // no match in mbed
+  else if(strstr(ptr,"WPA")) return NSAPI_SECURITY_WPA;
+  else return NSAPI_SECURITY_UNKNOWN;
 }
 
 /**


### PR DESCRIPTION
Scan function parses the security level of the various APs.
It calls ParseSecurity to get the security level of the current AP.
This ParseSecurity function stops searching when WPA is matching. WPA2 / WPA_WPA2 cannot be found.

With this PR, we can match also WPA2 / WPA_WPA2 security levels.


