### PR TITLE
Support space char in AP name

### DIFF
--- a/ISM43362/ATParser/ATParser.cpp
+++ b/ISM43362/ATParser/ATParser.cpp
@@ -326,7 +326,7 @@ restart:
 
             // Check for match
             int count = -1;
-            if (whole_line_wanted && c != '\n' && c != ' ') {
+            if (whole_line_wanted && c != '\n') {
                 // Don't attempt scanning until we get delimiter if they included it in format
                 // This allows recv("Foo: %s\n") to work, and not match with just the first character of a string
                 // (scanf does not itself match whitespace in its format string, so \n is not significant to it)


### PR DESCRIPTION
ATParser is skipping the space char. This means that we cannot connect to an AP that has a space in its name.

With this PR, the space char is no more bypassed by the ATParser.
The consequence is that we need to change the `reset `and `check_response `function s (the way they receive the prompt line `"> "` that contains a space)
And we need to use `_parser.recv("%[^\n]\r\n", tmp_buffer)`  instead of `_parser.recv("%s\r\n", tmp_buffer) ` in the  driver so that it can accept space in the sscanf functions.

The code is now able to connect to an AP that contains a space.
TO DO: non regression tests