### PR TITLE
ISM Connect procedure can now return NSAPI_ERROR enum

### DIFF
--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -77,9 +77,9 @@ public:
     * @param ap the name of the AP
     * @param passPhrase the password of AP
     * @param ap_sec the security level of network AP
-    * @return true only if ISM43362 is connected successfully
+    * @return nsapi_error enum
     */
-    bool connect(const char *ap, const char *passPhrase, ism_security_t ap_sec);
+    int connect(const char *ap, const char *passPhrase, ism_security_t ap_sec);
 
     /**
     * Disconnect ISM43362 from AP

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -1,5 +1,5 @@
 /* ISM43362 implementation of NetworkInterfaceAPI
- * Copyright (c) STMicroelectronics 2017
+ * Copyright (c) STMicroelectronics 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #define ism_debug false
 
 // Various timeouts for different ISM43362 operations
-#define ISM43362_CONNECT_TIMEOUT 15000 /* milliseconds */
+#define ISM43362_CONNECT_TIMEOUT 50000 /* milliseconds */
 #define ISM43362_SEND_TIMEOUT    1000   /* milliseconds */
 #define ISM43362_RECV_TIMEOUT    100   /* milliseconds */
 #define ISM43362_MISC_TIMEOUT    100   /* milliseconds */
@@ -87,11 +87,12 @@ int ISM43362Interface::connect()
     }
 
     _ism.setTimeout(ISM43362_CONNECT_TIMEOUT);
+    int connect_status = _ism.connect(ap_ssid, ap_pass, ap_sec);
+    debug_if(_ism_debug, "ISM43362Interface: connect_status %d\n", connect_status);
 
-    if (!_ism.connect(ap_ssid, ap_pass, ap_sec)) {
-//        debug_if(_ism_debug, "ISM43362Interface: connect_status %d\n", connect_status);
+    if (connect_status != NSAPI_ERROR_OK) {
         _mutex.unlock();
-        return NSAPI_ERROR_NO_CONNECTION;
+        return connect_status;
     }
 
     _ism.setTimeout(ISM43362_MISC_TIMEOUT);


### PR DESCRIPTION
There was issue with some failed connect procedure.

Log was:
```
[1527582352.78][CONN][RXD] AT> C0
[1527582352.78][CONN][RXD]
[1527582352.79][CONN][RXD] NO DATA, read again
[1527582372.85][CONN][INF] found KV pair in stream: {{__testcase_finish;WIFI-CONNECT-SECURE-FAIL;1;0}}, queued...

```

After increasing the timeout value, I got new log:
```
[1527582623.50][CONN][RXD] AT> C0
[1527582623.52][CONN][RXD]
[1527582623.53][CONN][RXD] NO DATA, read again
[1527582644.80][CONN][RXD] AT? ====OK
[1527582644.81][CONN][RXD] %n====
[1527582644.92][CONN][RXD] 5B 4A 4F 49 4E 20 20 20 5D 20 4E 45 54 47 45 41 52 5F 4D 42 45 44  D  A New line AT<<< [JOIN   ] NETGEAR_MBED
[1527582645.02][CONN][RXD] 5B 4A 4F 49 4E 20 20 20 5D 20 46 61 69 6C 65 64  D  A New line AT<<< [JOIN   ] Failed
[1527582645.13][CONN][RXD] 45 52 52 4F 52 3A 20 55 6E 6B 6E 6F 77 6E 20 45 72 72 6F 72  D  A New line AT<<< ERROR: Unknown Error
[1527582645.19][CONN][RXD] 55 73 61 67 65 3A 20 43 30 20  D  A New line AT<<< Usage: C0
[1527582645.22][CONN][RXD] 3E 20 AT(Timeout)
[1527582645.27][CONN][INF] found KV pair in stream: {{__testcase_finish;WIFI-CONNECT-SECURE-FAIL;1;0}}, queued...

```

Issue is then the one from #12 

This patch is then a code proposal to enable different status from the connect procedure.


