### PR TITLE
Removed timeout code as it was not useful

### DIFF
--- a/ISM43362/ATParser/ATParser.h
+++ b/ISM43362/ATParser/ATParser.h
@@ -26,6 +26,7 @@
 #include "BufferedSpi.h"
 #include "Callback.h"
 
+#define DEFAULT_SPI_TIMEOUT 60000 /* 1 minute */
 
 /**
 * Parser class for parsing AT commands
@@ -51,7 +52,6 @@ private:
     int _buffer_size;
     char *_buffer;
     Mutex _bufferMutex;
-    volatile int _timeout;
 
     // Parsing information
     const char *_delimiter;
@@ -77,7 +77,7 @@ public:
     * @param timeout timeout of the connection
     * @param delimiter string of characters to use as line delimiters
     */
-    ATParser(BufferedSpi &serial_spi, const char *delimiter = "\r\n", int buffer_size = 1440, int timeout = 8000, bool debug = false) :
+    ATParser(BufferedSpi &serial_spi, const char *delimiter = "\r\n", int buffer_size = 1440, int timeout = DEFAULT_SPI_TIMEOUT, bool debug = false) :
         _serial_spi(&serial_spi),
         _buffer_size(buffer_size), _in_prev(0), _oobs(NULL)
     {
@@ -107,7 +107,6 @@ public:
     */
     void setTimeout(int timeout)
     {
-        _timeout = timeout;
         _serial_spi->setTimeout(timeout);
     }
 

--- a/ISM43362/ATParser/BufferedSpi/BufferedSpi.h
+++ b/ISM43362/ATParser/BufferedSpi/BufferedSpi.h
@@ -190,14 +190,12 @@ public:
     /**
     * Allows timeout to be changed between commands
     *
-    * @param timeout timeout of the connection
+    * @param timeout timeout of the connection in ms
     */
     void setTimeout(int timeout)
     {
-        /*  this is a safe guard timeout in case module is stuck
-         *  so take 5 sec margin compared to module timeout, to
-         *  really only detect case where module is stuck */
-        _timeout = timeout + 5000;
+        /*  this is a safe guard timeout at SPI level in case module is stuck */
+        _timeout = timeout;
     }
 
     /** Register a callback once any data is ready for sockets

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -185,13 +185,6 @@ public:
     bool close(int id);
 
     /**
-    * Allows timeout to be changed between commands
-    *
-    * @param timeout_ms timeout of the connection
-    */
-    void setTimeout(uint32_t timeout_ms);
-
-    /**
     * Checks if data is available
     */
     bool readable();
@@ -233,7 +226,6 @@ private:
     BufferedSpi _bufferspi;
     ATParser _parser;
     DigitalOut _resetpin;
-    volatile int _timeout;
     volatile int _active_id;
     void print_rx_buff(void);
     bool check_response(void);


### PR DESCRIPTION
In the Inventek UM, timeout value are defined only
for send and receive data
once the Transport Protocol has been defined
and either the server or client mode has been enabled

So other timeout values seem to be not useful

### Patch:

- I keep the current timeout feature in AT and SPI side with 1 minute value to detect WIFI HW potential failure

- Set Read Transport Timeout value to 1ms

### Test 
+-------------------------+---------------------+------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite                         | test case                              | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-connectivity       | Bringing the network up and down       | 1      | 0      | OK     | 4.2                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-connectivity       | Bringing the network up and down twice | 1      | 0      | OK     | 7.63               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-gethostbyname      | DNS literal                            | 1      | 0      | OK     | 0.1                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-gethostbyname      | DNS preference literal                 | 1      | 0      | OK     | 0.13               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-gethostbyname      | DNS preference query                   | 1      | 0      | OK     | 0.15               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-gethostbyname      | DNS query                              | 1      | 0      | OK     | 0.18               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Hollowed IPv6 address                  | 1      | 0      | OK     | 0.05               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Left-weighted IPv4 address             | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Left-weighted IPv6 address             | 1      | 0      | OK     | 0.05               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Null IPv4 address                      | 1      | 0      | OK     | 0.04               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Null IPv6 address                      | 1      | 0      | OK     | 0.05               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Right-weighted IPv4 address            | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Right-weighted IPv6 address            | 1      | 0      | OK     | 0.04               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Simple IPv4 address                    | 1      | 0      | OK     | 0.03               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-ip_parsing         | Simple IPv6 address                    | 1      | 0      | OK     | 0.05               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-socket_sigio       | Socket Attach Test                     | 1      | 0      | OK     | 1.26               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-socket_sigio       | Socket Detach Test                     | 1      | 0      | OK     | 5.4                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-socket_sigio       | Socket Reattach Test                   | 1      | 0      | OK     | 0.59               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp_echo           | TCP echo                               | 1      | 0      | OK     | 14.87              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp_hello_world    | TCP hello world                        | 1      | 0      | OK     | 5.52               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp_dtls_handshake | UDP DTLS handshake                     | 0      | 0      | ERROR  | 0.0                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp_echo           | UDP echo                               | 1      | 0      | OK     | 86.32              |
+-------------------------+---------------------+------------------------------------+----------------------------------------+--------+--------+--------+--------------------+

+-------------------------+---------------------+--------------------+------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite         | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+--------------------+------------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT                       | 1      | 0      | OK     | 1.31               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-DISCONNECT-REPEAT     | 1      | 0      | OK     | 13.32              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-NOCREDENTIALS         | 1      | 0      | OK     | 0.04               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-PARAMS-CHANNEL        | 1      | 0      | OK     | 0.11               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-PARAMS-CHANNEL-FAIL   | 1      | 0      | OK     | 0.11               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-PARAMS-NULL           | 1      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-PARAMS-VALID-SECURE   | 1      | 0      | OK     | 3.69               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-PARAMS-VALID-UNSECURE | 1      | 0      | OK     | 1.36               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-SECURE                | 1      | 0      | OK     | 3.75               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONNECT-SECURE-FAIL           | 1      | 0      | OK     | 21.36              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-CONSTRUCTOR                   | 1      | 0      | OK     | 0.57               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-GET-RSSI                      | 1      | 0      | OK     | 2.13               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-SCAN                          | 1      | 0      | OK     | 2.81               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-SCAN-NULL                     | 1      | 0      | OK     | 2.8                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-SET-CHANNEL                   | 1      | 0      | OK     | 0.1                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi | WIFI-SET-CREDENTIAL                | 1      | 0      | OK     | 0.05               |
+-------------------------+---------------------+--------------------+------------------------------------+--------+--------+--------+--------------------+


