### PR TITLE
Create mbed_lib.json config file

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -37,8 +37,8 @@ const char supported_fw_versions[2][15] = {"C3.5.2.3.BETA9", "C3.5.2.2"};
 #define MIN(a,b) (((a)<(b))?(a):(b))
 
 // ISM43362Interface implementation
-ISM43362Interface::ISM43362Interface(PinName mosi, PinName miso, PinName sclk, PinName nss, PinName reset, PinName datareadypin, PinName wakeup, bool debug)
-    : _ism(mosi, miso, sclk, nss, reset, datareadypin, wakeup, debug)
+ISM43362Interface::ISM43362Interface(bool debug)
+    : _ism(MBED_CONF_ISM43362_WIFI_MOSI, MBED_CONF_ISM43362_WIFI_MISO, MBED_CONF_ISM43362_WIFI_SCLK, MBED_CONF_ISM43362_WIFI_NSS, MBED_CONF_ISM43362_WIFI_RESET, MBED_CONF_ISM43362_WIFI_DATAREADY, MBED_CONF_ISM43362_WIFI_WAKEUP, debug)
 {
     memset(_ids, 0, sizeof(_ids));
     memset(_socket_obj, 0, sizeof(_socket_obj));

--- a/ISM43362Interface.h
+++ b/ISM43362Interface.h
@@ -30,13 +30,9 @@ class ISM43362Interface : public NetworkStack, public WiFiInterface
 {
 public:
     /** ISM43362Interface lifetime
-     * @param mosi       MOSI pin
-     * @param miso       MISO pin
-     * @param clk        CLOCK pin
-     * @param nss        NSS pin
      * @param debug     Enable debugging
      */
-    ISM43362Interface(PinName mosi, PinName miso, PinName clk, PinName nss, PinName reset, PinName dataready, PinName wakeup, bool debug = false);
+    ISM43362Interface(bool debug = false);
 
     /** Start the interface
      *
@@ -134,7 +130,6 @@ public:
      *
      * @param  ap       Pointer to allocated array to store discovered AP
      * @param  count    Size of allocated @a res array, or 0 to only count available AP
-     * @param  timeout  Timeout in milliseconds; 0 for no timeout (Default: 0)
      * @return          Number of entries in @a, or if @a count was 0 number of available networks, negative on error
      *                  see @a nsapi_error
      */

--- a/README.md
+++ b/README.md
@@ -10,34 +10,32 @@ ISM43362 module is soldered on the following platforms from STMicroelectronics
 Add the following lines to the target_overrides section of mbed_app.json of your application
 ```
 "DISCO_L475VG_IOT1A": {
-    "wifi-spi_miso": "PC_11",
-    "wifi-spi_mosi": "PC_12",
-    "wifi-spi_sclk": "PC_10",
-    "wifi-spi_nss": "PE_0",
-    "wifi-reset": "PE_8",
-    "wifi-dataready": "PE_1",
-    "wifi-wakeup": "PB_13"
+    "ism43362.wifi-miso": "PC_11",
+    "ism43362.wifi-mosi": "PC_12",
+    "ism43362.wifi-sclk": "PC_10",
+    "ism43362.wifi-nss": "PE_0",
+    "ism43362.wifi-reset": "PE_8",
+    "ism43362.wifi-dataready": "PE_1",
+    "ism43362.wifi-wakeup": "PB_13"
 },
 "DISCO_F413ZH": {
-    "wifi-spi_miso": "PB_4",
-    "wifi-spi_mosi": "PB_5",
-    "wifi-spi_sclk": "PB_12",
-    "wifi-spi_nss": "PG_11",
-    "wifi-reset": "PH_1",
-    "wifi-dataready": "PG_12",
-    "wifi-wakeup": "PB_15"
+    "ism43362.wifi-miso": "PB_4",
+    "ism43362.wifi-mosi": "PB_5",
+    "ism43362.wifi-sclk": "PB_12",
+    "ism43362.wifi-nss": "PG_11",
+    "ism43362.wifi-reset": "PH_1",
+    "ism43362.wifi-dataready": "PG_12",
+    "ism43362.wifi-wakeup": "PB_15"
 }
 ```
 
-- MBED_CFG_ISM43362_SSID - SSID of the wifi access point to connect to
-- MBED_CFG_ISM43362_PASS - Passphrase of the wifi access point to connect to
-- MBED_CONF_APP_WIFI_SPI_MISO - spi-miso pin for the ism43362 connection
-- MBED_CONF_APP_WIFI_SPI_MOSI - spi-mosi pin for the ism43362 connection
-- MBED_CONF_APP_WIFI_SPI_SCLK - spi-clock pin for the ism43362 connection
-- MBED_CONF_APP_WIFI_SPI_NSS - spi-nss pin for the ism43362 connection
-- MBED_CONF_APP_WIFI_RESET - Reset pin for the ism43362 wifi module
-- MBED_CONF_APP_WIFI_DATAREADY - Data Ready pin for the ism43362 wifi module
-- MBED_CONF_APP_WIFI_WAKEUP - Wakeup pin for the ism43362 wifi module
+- MBED_CONF_ISM43362_WIFI_MISO      : spi-miso pin for the ism43362 connection
+- MBED_CONF_ISM43362_WIFI__MOSI     : spi-mosi pin for the ism43362 connection
+- MBED_CONF_ISM43362_WIFI_SPI_SCLK  : spi-clock pin for the ism43362 connection
+- MBED_CONF_ISM43362_WIFI_SPI_NSS   : spi-nss pin for the ism43362 connection
+- MBED_CONF_ISM43362_WIFI_RESET     : Reset pin for the ism43362 wifi module
+- MBED_CONF_ISM43362_WIFI_DATAREADY : Data Ready pin for the ism43362 wifi module
+- MBED_CONF_ISM43362_WIFI_WAKEUP    : Wakeup pin for the ism43362 wifi module
 
 
 ## Firmware version

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,33 @@
+{
+    "name": "ism43362",
+    "config": {
+        "wifi-miso": {
+            "help": "SPI-MISO connection to external device",
+            "value": "NC"
+        },
+        "wifi-mosi": {
+            "help": "SPI-MOSI connection to external device",
+            "value": "NC"
+        },
+        "wifi-sclk": {
+            "help": "SPI-CLOCK connection to external device",
+            "value": "NC"
+        },
+        "wifi-nss": {
+            "help": "SPI chip select of external device",
+            "value": "NC"
+        },
+        "wifi-reset": {
+            "help": "ISM43362 reset",
+            "value": "NC"
+        },
+        "wifi-dataready": {
+            "help": "ISM43362 dataready",
+            "value": "NC"
+        },
+        "wifi-wakeup": {
+            "help": "ISM43362 wakeup",
+            "value": "NC"
+        }
+    }
+}


### PR DESCRIPTION
Hi

ISM43362 driver requires SPI pin configurations, which is now defined in a med_lib.json file
Code is then using generated macros.

This should correct #15 

mbed os files will be updated as soon as this PR is merged

Thx

@SeppoTakalo 
