### PR TITLE
Add supported targets configuration direct in mbed_lib.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,10 @@ ISM43362 module is soldered on the following platforms from STMicroelectronics
 * DISCO_F413ZH
 
 ## Configuration
-Add the following lines to the target_overrides section of mbed_app.json of your application
-```
-"DISCO_L475VG_IOT1A": {
-    "ism43362.wifi-miso": "PC_11",
-    "ism43362.wifi-mosi": "PC_12",
-    "ism43362.wifi-sclk": "PC_10",
-    "ism43362.wifi-nss": "PE_0",
-    "ism43362.wifi-reset": "PE_8",
-    "ism43362.wifi-dataready": "PE_1",
-    "ism43362.wifi-wakeup": "PB_13"
-},
-"DISCO_F413ZH": {
-    "ism43362.wifi-miso": "PB_4",
-    "ism43362.wifi-mosi": "PB_5",
-    "ism43362.wifi-sclk": "PB_12",
-    "ism43362.wifi-nss": "PG_11",
-    "ism43362.wifi-reset": "PH_1",
-    "ism43362.wifi-dataready": "PG_12",
-    "ism43362.wifi-wakeup": "PB_15"
-}
-```
+
+Correct pins have already been configured for both supported platforms.
+
+Here is configured pins:
 
 - MBED_CONF_ISM43362_WIFI_MISO      : spi-miso pin for the ism43362 connection
 - MBED_CONF_ISM43362_WIFI__MOSI     : spi-mosi pin for the ism43362 connection
@@ -44,5 +27,3 @@ This driver supports ISM43362-M3G-L44-SPI,C3.5.2.3.BETA9 and C3.5.2.2 firmware v
 ## wifi module FW update
 For more information about the wifi FW version, refer to the detailed procedure in
 http://www.st.com/content/st_com/en/products/embedded-software/mcus-embedded-software/stm32-embedded-software/stm32cube-embedded-software-expansion/x-cube-azure.html
-
-```

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -29,5 +29,25 @@
             "help": "ISM43362 wakeup",
             "value": "NC"
         }
-    }
+    },
+    "target_overrides": {
+        "DISCO_F413ZH": {
+            "ism43362.wifi-miso": "PB_4",
+            "ism43362.wifi-mosi": "PB_5",
+            "ism43362.wifi-sclk": "PB_12",
+            "ism43362.wifi-nss": "PG_11",
+            "ism43362.wifi-reset": "PH_1",
+            "ism43362.wifi-dataready": "PG_12",
+            "ism43362.wifi-wakeup": "PB_15"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "ism43362.wifi-miso": "PC_11",
+            "ism43362.wifi-mosi": "PC_12",
+            "ism43362.wifi-sclk": "PC_10",
+            "ism43362.wifi-nss": "PE_0",
+            "ism43362.wifi-reset": "PE_8",
+            "ism43362.wifi-dataready": "PE_1",
+            "ism43362.wifi-wakeup": "PB_13"
+        }
+     }
 }


### PR DESCRIPTION
In order to make the Wifi driver easier for all users,
I propose to add pin configuration for both supported platforms direc tin the mbed_lib.json file

Currently already tested with mbed-os wifi test and mbed-os-example-client
