### PR TITLE
Update firmware version management

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -61,10 +61,10 @@ extern "C" int32_t ParseNumber(char *ptr, uint8_t *cnt)
         ptr++;
         i++;
     }
-    if (*ptr == 'C') {  /* input string for version is C3.x.x.x */
+    if (*ptr == 'C') {  /* input string from get_firmware_version is Cx.x.x.x */
         ptr++;
-        i++;
     }
+
     while (CHARISNUM(*ptr) || (*ptr == '.')) { /* Parse number */
         if (*ptr == '.') {
             ptr++; // next char

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -41,6 +41,8 @@ typedef enum ism_security {
     ISM_SECURITY_UNKNOWN      = 0xFF,     /*!< unknown/unsupported security in scan results */
 } ism_security_t;
 
+extern "C" int32_t ParseNumber(char *ptr, uint8_t *cnt);
+
 /** ISM43362Interface class.
     This is an interface to a ISM43362 radio.
  */

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -51,9 +51,9 @@ public:
     /**
     * Check firmware version of ISM43362
     *
-    * @return null-terminated fw version or null if no version is read
+    * @return fw version or null if no version is read
     */
-    const char *get_firmware_version(void);
+    uint32_t get_firmware_version(void);
 
     /**
     * Reset ISM43362
@@ -250,7 +250,7 @@ private:
     char _gateway_buffer[16];
     char _netmask_buffer[16];
     char _mac_buffer[18];
-    char _fw_version[16];
+    uint32_t _FwVersionId;
 };
 
 #endif

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -18,6 +18,9 @@
 #include "ISM43362Interface.h"
 #include "mbed_debug.h"
 
+                                            // Product ID,FW Revision,API Revision,Stack Revision,RTOS Revision,CPU Clock,Product Name
+#define LATEST_FW_VERSION_NUMBER "C3.5.2.5" // ISM43362-M3G-L44-SPI,C3.5.2.5.STM,v3.5.2,v1.4.0.rc1,v8.2.1,120000000,Inventek eS-WiFi
+
 // activate / de-activate debug
 #define ism_debug false
 
@@ -53,9 +56,15 @@ ISM43362Interface::ISM43362Interface(bool debug)
     if (!_FwVersion) {
         error("ISM43362Interface: ERROR cannot read firmware version\r\n");
     }
+
     debug_if(_ism_debug, "ISM43362Interface: read_version = %lu\r\n", _FwVersion);
+    /* FW Revision should be with format "CX.X.X.X" with X as a single digit */
+    if ( (_FwVersion < 1000) || (_FwVersion > 9999) ) {
+        debug_if(_ism_debug, "ISM43362Interface: read_version issue\r\n");
+    }
+
 #if TARGET_DISCO_L475VG_IOT01A
-    if (_FwVersion < 3525) {
+    if (_FwVersion < ParseNumber(LATEST_FW_VERSION_NUMBER, NULL)) {
         debug_if(_ism_debug, "ISM43362Interface: please update FW\r\n");
     }
 #endif

--- a/ISM43362Interface.h
+++ b/ISM43362Interface.h
@@ -278,6 +278,7 @@ private:
     char ap_pass[64]; /* The longest allowed passphrase */
 
     bool _ism_debug;
+    uint32_t _FwVersion;
 
     void event();
     struct {

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # ISM43362 WiFi driver for mbed-os
+
 The mbed OS driver for the ISM43362 WiFi module
 
+https://www.inventeksys.com/products-page/wifi-modules/ism4336-m3g-l44-e-embedded-serial-to-wifi-module/
+
+
 ## Currently supported platforms
+
 ISM43362 module is soldered on the following platforms from STMicroelectronics
-* DISCO_L475VG_IOT01A
-* DISCO_F413ZH
+
+ * [DISCO_L475VG_IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/)
+ * [DISCO_F413ZH](https://os.mbed.com/platforms/ST-Discovery-F413H/)
 
 ## Configuration
 
@@ -22,8 +28,12 @@ Here is configured pins:
 
 
 ## Firmware version
-This driver supports ISM43362-M3G-L44-SPI,C3.5.2.3.BETA9 and C3.5.2.2 firmware version
+
+This driver has been tested with C3.5.2.2 and C3.5.2.3.BETA9 firmware version
 
 ## wifi module FW update
+
+Only Wifi module from DISCO_L475VG_IOT01A can be updated (HW limitation for DISCO_F413ZH).
+
 For more information about the wifi FW version, refer to the detailed procedure in
 http://www.st.com/content/st_com/en/products/embedded-software/mcus-embedded-software/stm32-embedded-software/stm32cube-embedded-software-expansion/x-cube-azure.html


### PR DESCRIPTION
To make version check easier, version is now an integer.

DISCO_F413ZH version : 3522
IOT board version can be updated.

md file has been updated.
