### PR TITLE
mbed-os wifi netsocket tests with MBED_EXTENDED_TESTS macro

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -522,6 +522,7 @@ bool ISM43362::open(const char *type, int id, const char *addr, int port)
         return -1;
     }
 
+    debug_if(_ism_debug, "ISM43362: open ok with id %d type %s addr %s port %d\n", id, type, addr, port);
     return true;
 }
 
@@ -544,7 +545,7 @@ bool ISM43362::dns_lookup(const char *name, char *ip)
 bool ISM43362::send(int id, const void *data, uint32_t amount)
 {
     // The Size limit has to be checked on caller side.
-    if (amount > ES_WIFI_MAX_RX_PACKET_SIZE) {
+    if (amount > ES_WIFI_MAX_TX_PACKET_SIZE) {
         return false;
     }
 

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -122,6 +122,10 @@ int ISM43362Interface::connect()
 
 nsapi_error_t ISM43362Interface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
 {
+    if (strlen(name) == 0) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
     _mutex.lock();
     if (address->set_ip_address(name)) {
         if (version != NSAPI_UNSPEC && address->get_ip_version() != version) {


### PR DESCRIPTION
MBED_EXTENDED_TESTS macro needs few update in our wifi driver.

Test result is OK now!


+-------------------------+---------------------+---------------------+------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite          | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+---------------------+------------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_CONNECT_INVALID          | 1      | 0      | OK     | 0.12               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST                 | 1      | 0      | OK     | 2.8                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_BURST           | 1      | 0      | OK     | 13.5               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_BURST_NONBLOCK  | 1      | 0      | OK     | 16.53              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 23.03              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ENDPOINT_CLOSE           | 0      | 1      | OK     | 0.68               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_RECV_100K                | 1      | 0      | OK     | 2.45               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_RECV_100K_NONBLOCK       | 1      | 0      | OK     | 2.78               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_RECV_TIMEOUT             | 1      | 0      | OK     | 1.54               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_SEND_REPEAT              | 1      | 0      | OK     | 5.1                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_SEND_TIMEOUT             | 1      | 0      | OK     | 0.12               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_THREAD_PER_SOCKET_SAFETY | 1      | 0      | OK     | 1.24               |
+-------------------------+---------------------+---------------------+------------------------------------+--------+--------+--------+--------------------+


+------------------+---------------+---------------------+------------------------------------+--------+--------+--------+--------------------+
| target           | platform_name | test suite          | test case                          | passed | failed | result | elapsed_time (sec) |
+------------------+---------------+---------------------+------------------------------------+--------+--------+--------+--------------------+
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_CONNECT_INVALID          | 1      | 0      | OK     | 0.32               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST                 | 1      | 0      | OK     | 1.93               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_BURST           | 1      | 0      | OK     | 14.85              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_BURST_NONBLOCK  | 1      | 0      | OK     | 12.09              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 23.25              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ENDPOINT_CLOSE           | 1      | 0      | OK     | 0.63               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.07               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.3                |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_RECV_100K                | 1      | 0      | OK     | 3.33               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_RECV_100K_NONBLOCK       | 1      | 0      | OK     | 3.36               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_RECV_TIMEOUT             | 1      | 0      | OK     | 1.17               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_SEND_REPEAT              | 1      | 0      | OK     | 5.85               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_SEND_TIMEOUT             | 1      | 0      | OK     | 0.24               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_THREAD_PER_SOCKET_SAFETY | 1      | 0      | OK     | 1.37               |
+------------------+---------------+---------------------+------------------------------------+--------+--------+--------+--------------------+

