### PR TITLE
Reduce SPI buffer to a single buffer

### DIFF
--- a/ISM43362/ATParser/BufferedSpi/BufferedSpi.h
+++ b/ISM43362/ATParser/BufferedSpi/BufferedSpi.h
@@ -110,7 +110,7 @@ public:
      *  @param tx_multiple amount of max printf() present in the internal ring buffer at one time
      *  @param name optional name
     */
-    BufferedSpi(PinName mosi, PinName miso, PinName sclk, PinName nss, PinName datareadypin, uint32_t buf_size = 2500, uint32_t tx_multiple = 4, const char *name = NULL);
+    BufferedSpi(PinName mosi, PinName miso, PinName sclk, PinName nss, PinName datareadypin, uint32_t buf_size = 2500, uint32_t tx_multiple = 1, const char *name = NULL);
 
     /** Destroy a BufferedSpi Port
      */


### PR DESCRIPTION
The ISM43362 WIFI drivers works in a command / response mechanism
that does not allow buffering. For each command that is sent, an answer
is awaited until the next command will be accepted.

As a consequence, there is no need to allow a multple number of buffers
to be managed in BufferedSPI object.

Reducing tx_multiple to 1 here also will free up to 7500 bytes of RAM
in Heap.