### PR TITLE
Allow ISM43362 to provide default WifiInterface

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -544,3 +544,12 @@ void ISM43362Interface::event()
         }
     }
 }
+
+#if MBED_CONF_ISM43362_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static ISM43362Interface ism;
+    return &ism;
+}
+
+#endif

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -32,6 +32,10 @@
         "wifi-debug": {
             "help": "Defines whether logging is on or off",
             "value": false
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
         }
     },
     "target_overrides": {
@@ -42,7 +46,8 @@
             "ism43362.wifi-nss": "PG_11",
             "ism43362.wifi-reset": "PH_1",
             "ism43362.wifi-dataready": "PG_12",
-            "ism43362.wifi-wakeup": "PB_15"
+            "ism43362.wifi-wakeup": "PB_15",
+            "ism43362.provide-default": true
         },
         "DISCO_L475VG_IOT01A": {
             "ism43362.wifi-miso": "PC_11",
@@ -51,7 +56,8 @@
             "ism43362.wifi-nss": "PE_0",
             "ism43362.wifi-reset": "PE_8",
             "ism43362.wifi-dataready": "PE_1",
-            "ism43362.wifi-wakeup": "PB_13"
+            "ism43362.wifi-wakeup": "PB_13",
+            "ism43362.provide-default": true
         }
      }
 }


### PR DESCRIPTION
ISM43362 can provide default WifiInterface for Mbed OS by setting
"ism43362.provide-default": true in the mbed_app.json.

DISCO_F413ZH and DISCO_L475VG_IOT01A configured to set this true.