### PR TITLE
gethostbyname should return NSAPI_ERROR_DNS_FAILURE instead of NSAPI_ERROR_DEVICE_ERROR

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -132,7 +132,7 @@ nsapi_error_t ISM43362Interface::gethostbyname(const char *name, SocketAddress *
     char *ipbuff = new char[NSAPI_IP_SIZE];
     int ret = 0;
     if (!_ism.dns_lookup(name, ipbuff)) {
-        ret = NSAPI_ERROR_DEVICE_ERROR;
+        ret = NSAPI_ERROR_DNS_FAILURE;
     } else {
         address->set_ip_address(ipbuff);
     }


### PR DESCRIPTION
Issue seen with mbed-os-tests-netsocket-dns

| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-dns | SYNCHRONOUS_DNS_INVALID               | 0      | 4      | FAIL   | 31.05              |

