### PR TITLE
Adding thread safety to the driver.

### DIFF
--- a/ISM43362/ATParser/BufferedSpi/BufferedSpi.cpp
+++ b/ISM43362/ATParser/BufferedSpi/BufferedSpi.cpp
@@ -86,6 +86,8 @@ BufferedSpi::BufferedSpi(PinName mosi, PinName miso, PinName sclk, PinName _nss,
     _datareadyInt->rise(callback(this, &BufferedSpi::DatareadyRising));
 
     _cmddata_rdy_rising_event = 1;
+    nss = 1;
+    wait_us(15);
 
     return;
 }
@@ -110,10 +112,12 @@ void BufferedSpi::disable_nss()
 {
     nss = 1;
     wait_us(15);
+    unlock();
 }
 
 void BufferedSpi::enable_nss()
 {
+    lock();
     nss = 0;
     wait_us(15);
 }
@@ -248,8 +252,6 @@ ssize_t BufferedSpi::read(uint32_t max)
     uint32_t len = 0;
     uint8_t FirstRemoved = 1;
     int tmp;
-
-    disable_nss();
 
     /* wait for data ready is up */
     if (wait_cmddata_rdy_rising_event() != 0) {


### PR DESCRIPTION
# What ?
When using an SDCard over the same spi interface things go wrong.

# Why ?
Both drivers are conflicting when accessing the bus.
The bufferedspi should use locks before asserting nss and unlock after releasing nss in order to keep it thread safe.

# How is this fixed ?
Adding a `lock()`/`unlock()` in `enable_nss()`/`disable_nss()` should fix the issue.