### PR TITLE
Connection lost during socket_recv

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -434,7 +434,7 @@ int ISM43362Interface::socket_recv(void *handle, void *data, unsigned size)
 
     if (!socket->connected) {
         _mutex.unlock();
-        return NSAPI_ERROR_CONNECTION_LOST;
+        return 0;
     }
 
     if (socket->read_data_size == 0) {
@@ -446,7 +446,7 @@ int ISM43362Interface::socket_recv(void *handle, void *data, unsigned size)
             socket->connected = false;
             debug_if(_ism_debug, "ISM43362Interface socket_recv: socket closed\r\n");
             _mutex.unlock();
-            return NSAPI_ERROR_CONNECTION_LOST;
+            return 0;
         }
     }
 


### PR DESCRIPTION
This fixes #29 

In  TCPSocket::recv() we need to return zero because closing a TCP socket it considered normal operation.
Details in #29 

@SeppoTakalo @screamerbg 
