### PR TITLE
Network status API implementation

### DIFF
--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -224,6 +224,13 @@ public:
         attach(Callback<void()>(obj, method));
     }
 
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    nsapi_connection_status_t connection_status() const;
+
+
 private:
     BufferedSpi _bufferspi;
     ATParser _parser;
@@ -245,6 +252,10 @@ private:
     char _netmask_buffer[16];
     char _mac_buffer[18];
     uint32_t _FwVersionId;
+
+    // Connection state reporting
+    nsapi_connection_status_t _conn_status;
+    mbed::Callback<void()> _conn_stat_cb;
 };
 
 #endif

--- a/ISM43362Interface.h
+++ b/ISM43362Interface.h
@@ -158,6 +158,22 @@ public:
      */
     using NetworkInterface::add_dns_server;
 
+    /** Register callback for status reporting
+     *
+     *  The specified status callback function will be called on status changes
+     *  on the network. The parameters on the callback are the event type and
+     *  event-type dependent reason parameter.
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual nsapi_connection_status_t get_connection_status() const;
+
 protected:
     /** Open a socket
      *  @param handle       Handle in which to store new socket
@@ -293,6 +309,12 @@ private:
     virtual void socket_check_read();
     int socket_send_nolock(void *handle, const void *data, unsigned size);
     int socket_connect_nolock(void *handle, const SocketAddress &addr);
+
+    // Connection state reporting to application
+    void update_conn_state_cb();
+    nsapi_connection_status_t _conn_stat;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb;
+
 
 };
 


### PR DESCRIPTION
This fixes #31 

https://os.mbed.com/docs/mbed-os/v5.11/apis/network-status.html

| target                  | platform_name       | test suite              | test case                          | passed | failed | result | elapsed_time (sec) |
|-------------------------|---------------------|-------------------------|------------------------------------|--------|--------|--------|--------------------|
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-interface | NETWORKINTERFACE_CONN_DISC_REPEAT  | 1      | 0      | OK     | 18.45              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-interface | NETWORKINTERFACE_STATUS            | 1      | 0      | OK     | 19.11              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-interface | NETWORKINTERFACE_STATUS_GET        | 1      | 0      | OK     | 18.44              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-interface | NETWORKINTERFACE_STATUS_NONBLOCK   | 1      | 0      | OK     | 18.52              |


@SeppoTakalo @screamerbg 