### PR TITLE
Allow statically allocating the wifi stack

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -18,6 +18,14 @@
 #include "ISM43362Interface.h"
 #include "mbed_debug.h"
 
+#if MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE != 0
+#if MBED_CONF_ISM43362_READ_THREAD_STACK_STATICALLY_ALLOCATED == 1
+static uint8_t ism_wifi_thread_stack[MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE];
+#else
+static uint8_t *ism_wifi_thread_stack = NULL;
+#endif // MBED_CONF_ISM43362_READ_THREAD_STACK_STATICALLY_ALLOCATED == 1
+#endif // MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE != 0
+
                                             // Product ID,FW Revision,API Revision,Stack Revision,RTOS Revision,CPU Clock,Product Name
 #define LATEST_FW_VERSION_NUMBER "C3.5.2.5" // ISM43362-M3G-L44-SPI,C3.5.2.5.STM,v3.5.2,v1.4.0.rc1,v8.2.1,120000000,Inventek eS-WiFi
 
@@ -30,7 +38,7 @@
 ISM43362Interface::ISM43362Interface(bool debug)
     : _ism(MBED_CONF_ISM43362_WIFI_MOSI, MBED_CONF_ISM43362_WIFI_MISO, MBED_CONF_ISM43362_WIFI_SCLK, MBED_CONF_ISM43362_WIFI_NSS, MBED_CONF_ISM43362_WIFI_RESET, MBED_CONF_ISM43362_WIFI_DATAREADY, MBED_CONF_ISM43362_WIFI_WAKEUP, debug),
 #if MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE != 0
-      thread_read_socket(osPriorityNormal, MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE),
+      thread_read_socket(osPriorityNormal, MBED_CONF_ISM43362_READ_THREAD_STACK_SIZE, ism_wifi_thread_stack, "ism43362"),
 #endif
       _conn_stat(NSAPI_STATUS_DISCONNECTED),
       _conn_stat_cb(NULL)

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -40,6 +40,10 @@
         "read-thread-stack-size": {
             "help": "Stack size of the read thread, defaults to MBED_CONF_APP_THREAD_STACK_SIZE or MBED_CONF_RTOS_THREAD_STACK_SIZE (default: 4096)",
             "value": null
+        },
+        "read-thread-stack-statically-allocated": {
+            "help": "Whether to statically allocate the memory for the read thread stack. Requires 'read-thread-stack-size' to be set.",
+            "value": false
         }
     },
     "target_overrides": {


### PR DESCRIPTION
On the DISCO-L475VG board we now have split the memory banks in 2. One for BSS section (RAM2) and one for the heap (RAM1). On one of my examples I need a lot more RAM1 space than RAM2 space, and right now the wifi stack always allocates a new thread with it's stack on the heap. This allows you to override this.

In an ideal world I'd also want to be able to allocate all the socket structs statically, but that's for another day.

Also, why is `read_data` size set to 1400 in the socket struct and not to `ES_WIFI_MAX_RX_PACKET_SIZE`?