### PR TITLE
Align Socket read buffer to WIFI module max read packet size

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -274,7 +274,7 @@ struct ISM43362_socket {
     nsapi_protocol_t proto;
     volatile bool connected;
     SocketAddress addr;
-    char read_data[1400];
+    char read_data[ES_WIFI_MAX_RX_PACKET_SIZE];
     volatile uint32_t read_data_size;
 };
 


### PR DESCRIPTION
Should fix #48 and save RAM memory.

@jeromecoutant - non-regression to be run before merging
