### PR TITLE
Revert "Align Socket read buffer to WIFI module max read packet size"

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -282,7 +282,7 @@ struct ISM43362_socket {
     nsapi_protocol_t proto;
     volatile bool connected;
     SocketAddress addr;
-    char read_data[ES_WIFI_MAX_RX_PACKET_SIZE];
+    char read_data[1400];
     volatile uint32_t read_data_size;
 };
 


### PR DESCRIPTION
With current master branch, 2 tests:

- tests-netsocket-tcp
- tests-netsocket-tls

was failing with DISCO_L475VG_IOT01A

Becomes back when revert #49 

Fix #51 
