### PR TITLE
Revert "Dimension SPI TX Buffer to cope with Max Data"

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -22,7 +22,7 @@
 #define ism_debug 0
 
 ISM43362::ISM43362(PinName mosi, PinName miso, PinName sclk, PinName nss, PinName resetpin, PinName datareadypin, PinName wakeup, bool debug)
-    : _bufferspi(mosi, miso, sclk, nss, datareadypin, ES_WIFI_MAX_TX_SPI_SIZE),
+    : _bufferspi(mosi, miso, sclk, nss, datareadypin),
       _parser(_bufferspi),
       _resetpin(resetpin),
       _packets(0), _packets_end(&_packets)

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -30,14 +30,8 @@
 // The input range for AT Command 'R1' is 0 to 1200 bytes
 // 'R1' Set Read Transport Packet Size (bytes)
 #define ES_WIFI_MAX_RX_PACKET_SIZE                     1200
-// Module maximum DATA payload for Tx packet is 1460
+// Module maxume DATA payload for Tx packet is 1460
 #define ES_WIFI_MAX_TX_PACKET_SIZE                     1460
-// Module maximum DATA SPI buffer is composed of:
-//   a preamble S3=xxxx\r where xxxx is the size of data
-//   Tx data itself
-// So max size is ES_WIFI_MAX_TX_PACKET_SIZE + the preamble size
-#define ES_WIFI_MAX_TX_SPI_SIZE      ES_WIFI_MAX_TX_PACKET_SIZE + 10
-
 typedef enum ism_security {
     ISM_SECURITY_NONE         = 0x0,      /*!< open access point */
     ISM_SECURITY_WEP          = 0x1,      /*!< phrase conforms to WEP */


### PR DESCRIPTION
This reverts commit a66d89d173f3eae08662b8ea89f8af59a641bec6 from #47 

See https://github.com/ARMmbed/wifi-ism43362/pull/47#pullrequestreview-222737246

Issue was seen with DISCO_F413ZH and tests-network-wifi

Fix #50 