### PR TITLE
Provide SocketAddress-based API functions.

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -209,6 +209,20 @@ const char *ISM43362Interface::get_ip_address()
     return ret;
 }
 
+nsapi_error_t ISM43362Interface::get_ip_address(SocketAddress *address)
+{
+    if (!address) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+    _mutex.lock();
+    if (address->set_ip_address(_ism.getIPAddress())) {
+        _mutex.unlock();
+        return NSAPI_ERROR_OK;
+    }
+    _mutex.unlock();
+    return NSAPI_ERROR_NO_ADDRESS;
+}
+
 const char *ISM43362Interface::get_mac_address()
 {
     _mutex.lock();
@@ -225,12 +239,40 @@ const char *ISM43362Interface::get_gateway()
     return ret;
 }
 
+nsapi_error_t ISM43362Interface::get_gateway(SocketAddress *address)
+{
+    if (!address) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+    _mutex.lock();
+    if (address->set_ip_address(_ism.getGateway())) {
+        _mutex.unlock();
+        return NSAPI_ERROR_OK;
+    }
+    _mutex.unlock();
+    return NSAPI_ERROR_NO_ADDRESS;
+}
+
 const char *ISM43362Interface::get_netmask()
 {
     _mutex.lock();
     const char *ret = _ism.getNetmask();
     _mutex.unlock();
     return ret;
+}
+
+nsapi_error_t ISM43362Interface::get_netmask(SocketAddress *address)
+{
+    if (!address) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+    _mutex.lock();
+    if (address->set_ip_address(_ism.getNetmask())) {
+        _mutex.unlock();
+        return NSAPI_ERROR_OK;
+    }
+    _mutex.unlock();
+    return NSAPI_ERROR_NO_ADDRESS;
 }
 
 char *ISM43362Interface::get_interface_name(char *interface_name)

--- a/ISM43362Interface.h
+++ b/ISM43362Interface.h
@@ -85,6 +85,8 @@ public:
      */
     virtual const char *get_ip_address();
 
+    virtual nsapi_error_t get_ip_address(SocketAddress *address);
+
     /** Get the internally stored MAC address
      *  @return             MAC address of the interface
      */
@@ -97,12 +99,16 @@ public:
     */
     virtual const char *get_gateway();
 
+    virtual nsapi_error_t get_gateway(SocketAddress *address);
+
     /** Get the local network mask
      *
      *  @return         Null-terminated representation of the local network mask
      *                  or null if no network mask has been recieved
      */
     virtual const char *get_netmask();
+
+    virtual nsapi_error_t get_netmask(SocketAddress *address);
 
     /** Get the network interface name
      *


### PR DESCRIPTION
String-based APIs are deprecated from mbed-os-5.15