### PR TITLE
ISM43362: check parameters are not NULL in open()

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -505,6 +505,12 @@ int ISM43362::scan(WiFiAccessPoint *res, unsigned limit)
 bool ISM43362::open(const char *type, int id, const char *addr, int port)
 {
     static uint16_t rnglocalport = 0;
+
+    if((type == NULL) || (addr == NULL)) {
+        debug_if(_ism_debug, "\tISM43362: parameter error\n");
+        return false;
+    }
+
     /* TODO : This is the implementation for the client socket, need to check if need to create openserver too */
     //IDs only 0-3
     if ((id < 0) || (id > 3)) {


### PR DESCRIPTION
Proposed fix for #66 