### PR TITLE
Country code

### DIFF
--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <string.h>
 #include <inttypes.h>
 #include "ISM43362.h"
 #include "mbed_debug.h"
@@ -196,40 +195,75 @@ bool ISM43362::dhcp(bool enabled)
     return (_parser.send("C4=%d", enabled ? 1 : 0) && check_response());
 }
 
-bool ISM43362::check_country_code(const char* country_codeP)
+/*
+  * @brief  Update wifi_module_country_code.
+  * @param  country_code: User's country code.
+  * @retval boolean value : false ->error
+
+WiFi module is only able to receive 4 country codes: CA, US, FR and JP.
+CA, US -> 11 channels
+FR     -> 13 channels
+JP     -> 14 channels
+
+Thus 3 country code groups can be defined :
+
+- Country Code Group corresponding to 11 channels : CountryCodeElevenChannels,
+- Country Code Group corresponding to 13 channels : CountryCodeThirteenChannels,
+- Country Code Group corresponding to 14 channels : CountryCodeFourteenChannels.
+
+For an user's country code (input country code), the function is specifying
+to which Country Code Group it is belonging.
+
+For instance,
+user's country code=VN (Vietnam - 13 channels) is belonging
+to CountryCodeThirteenChannels.
+
+Thus function is specifying that WIFI module must be configured
+with country code = FR.
+
+Function is updating WIFI_module_country_code with FR.
+
+*/
+
+#ifdef MBED_CONF_ISM43362_WIFI_COUNTRY_CODE
+bool ISM43362::check_country_code(const char* country_code)
 {
+  if ((!strcmp(country_code, "CA")) || (!strcmp(country_code, "US"))
+      || (!strcmp(country_code, "FR")) || (!strcmp(country_code, "JP")) )
+  {
+     strcpy(WIFI_module_country_code, country_code);
+    return true;
+  }
+
   int k = 0;
 
-  while(CountryCodeThirteenChannels[k] != "END")
+  while (strcmp(CountryCodeThirteenChannels[k].cc, "END"))
   {
-    if (CountryCodeThirteenChannels[k] == country_codeP)
+    if (!strcmp(CountryCodeThirteenChannels[k].cc, country_code))
+    {
+      strcpy(WIFI_module_country_code, "FR");
       return true;
+    }
 
     k++;
   }
 
   k = 0;
 
-  while(CountryCodeElevenChannels[k] != "END")
+  while (strcmp(CountryCodeElevenChannels[k].cc, "END"))
   {
-    if (CountryCodeThirteenChannels[k] == country_codeP)
+    if (!strcmp(CountryCodeElevenChannels[k].cc, country_code))
+    {
+      strcpy(WIFI_module_country_code, "US");
       return true;
-
-    k++;
-  }
-
-  k = 0;
-
-  while(CountryCodeFourteenChannels[k] != "END")
-  {
-    if (CountryCodeFourteenChannels[k] == country_codeP)
-      return true;
+    }
 
     k++;
   }
 
   return false;
 }
+#endif
 
 int ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_sec)
 {
@@ -253,6 +287,7 @@ int ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_
         return NSAPI_ERROR_PARAMETER;
     }
 
+#ifdef MBED_CONF_ISM43362_WIFI_COUNTRY_CODE
      /* Check country code is acceptable */
     bool ret = check_country_code(MBED_CONF_ISM43362_WIFI_COUNTRY_CODE);
     if (ret == false)
@@ -261,9 +296,10 @@ int ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_
       return NSAPI_ERROR_PARAMETER;
     }
 
-    if (!(_parser.send("CN=%s",  MBED_CONF_ISM43362_WIFI_COUNTRY_CODE) && check_response())) {
+    if (!(_parser.send("CN=%s/0",  WIFI_module_country_code) && check_response())) {
         return NSAPI_ERROR_PARAMETER;
     }
+#endif
 
     if (_parser.send("C0")) {
         while (_parser.recv("%[^\n]\n", tmp)) {
@@ -497,6 +533,7 @@ int ISM43362::scan(WiFiAccessPoint *res, unsigned limit)
             debug_if(_ism_debug, "\tISM43362: scan error\r\n");
             return 0;
         }
+
     } else {
         if (!(_parser.send("F0"))) {
             debug_if(_ism_debug, "\tISM43362: scan error\r\n");
@@ -589,11 +626,11 @@ int ISM43362::scan(WiFiAccessPoint *res, unsigned limit)
                 res[cnt] = WiFiAccessPoint(ap);
             }
             cnt++;
-        } // else ?
+        }
 
         if (AP_Scan_1by1 == true) {
             _parser.flush();
-            /* retrive next AP */
+            /* retrieve next AP */
             if (!(_parser.send("MR"))) {
                 debug_if(_ism_debug, "\tISM43362: scan error\r\n");
                 return 0;

--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -237,7 +237,7 @@ bool ISM43362::check_country_code(const char* country_code)
 
   int k = 0;
 
-  while (strcmp(CountryCodeThirteenChannels[k].cc, "END"))
+  while (strcmp(CountryCodeThirteenChannels[k].cc, "ED"))
   {
     if (!strcmp(CountryCodeThirteenChannels[k].cc, country_code))
     {
@@ -250,7 +250,7 @@ bool ISM43362::check_country_code(const char* country_code)
 
   k = 0;
 
-  while (strcmp(CountryCodeElevenChannels[k].cc, "END"))
+  while (strcmp(CountryCodeElevenChannels[k].cc, "ED"))
   {
     if (!strcmp(CountryCodeElevenChannels[k].cc, country_code))
     {
@@ -533,7 +533,6 @@ int ISM43362::scan(WiFiAccessPoint *res, unsigned limit)
             debug_if(_ism_debug, "\tISM43362: scan error\r\n");
             return 0;
         }
-
     } else {
         if (!(_parser.send("F0"))) {
             debug_if(_ism_debug, "\tISM43362: scan error\r\n");

--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -196,6 +196,41 @@ bool ISM43362::dhcp(bool enabled)
     return (_parser.send("C4=%d", enabled ? 1 : 0) && check_response());
 }
 
+bool ISM43362::check_country_code(const char* country_codeP)
+{
+  int k = 0;
+
+  while(CountryCodeThirteenChannels[k] != "END")
+  {
+    if (CountryCodeThirteenChannels[k] == country_codeP)
+      return true;
+
+    k++;
+  }
+
+  k = 0;
+
+  while(CountryCodeElevenChannels[k] != "END")
+  {
+    if (CountryCodeThirteenChannels[k] == country_codeP)
+      return true;
+
+    k++;
+  }
+
+  k = 0;
+
+  while(CountryCodeFourteenChannels[k] != "END")
+  {
+    if (CountryCodeFourteenChannels[k] == country_codeP)
+      return true;
+
+    k++;
+  }
+
+  return false;
+}
+
 int ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_sec)
 {
     char tmp[256];
@@ -215,6 +250,18 @@ int ISM43362::connect(const char *ap, const char *passPhrase, ism_security_t ap_
     }
 
     if (!(_parser.send("C3=%d", ap_sec) && check_response())) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+     /* Check country code is acceptable */
+    bool ret = check_country_code(MBED_CONF_ISM43362_WIFI_COUNTRY_CODE);
+    if (ret == false)
+    {
+      printf("ISM43362::connect Country Code ERROR\n");
+      return NSAPI_ERROR_PARAMETER;
+    }
+
+    if (!(_parser.send("CN=%s",  MBED_CONF_ISM43362_WIFI_COUNTRY_CODE) && check_response())) {
         return NSAPI_ERROR_PARAMETER;
     }
 

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -257,11 +257,11 @@ private:
 
     typedef struct
     {
-      char cc[5];
+      char cc[3];
     } COUNTRY_CODE;
 
     COUNTRY_CODE CountryCodeElevenChannels[12] = {"AS", "CA", "FM", "GU", "KY", "MP", "PR", "TW",
-                                                 "UM", "US", "VI", "END"};
+                                                 "UM", "US", "VI", "ED"};
 
     COUNTRY_CODE CountryCodeThirteenChannels[127] = {"AE", "AG", "AN", "AR", "AT", "AU", "AW",
                                                     "AZ", "BA", "BB", "BD", "BE", "BG", "BH",
@@ -281,7 +281,7 @@ private:
                                                     "SE", "SG", "SI", "SK", "SV", "TH", "TJ",
                                                     "TN", "TR", "TT", "TZ", "UA", "UY", "UZ",
                                                     "VA", "VE", "VG", "VN", "YT", "ZA", "ZM",
-                                                    "END"};
+                                                    "ED"};
 };
 
 #endif

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -230,7 +230,12 @@ private:
     volatile int _active_id;
     void print_rx_buff(void);
     bool check_response(void);
+
+#ifdef MBED_CONF_ISM43362_WIFI_COUNTRY_CODE
     bool check_country_code(const char* country_code);
+    char WIFI_module_country_code[5];
+#endif
+
     struct packet {
         struct packet *next;
         int id;
@@ -250,30 +255,33 @@ private:
     nsapi_connection_status_t _conn_status;
     mbed::Callback<void()> _conn_stat_cb;
 
-    string CountryCodeElevenChannels[12] = {"AS", "CA", "FM", "GU", "KY", "MP", "PR", "TW",
-                                        "UM", "US", "VI", "END"};
+    typedef struct
+    {
+      char cc[5];
+    } COUNTRY_CODE;
 
-    string CountryCodeThirteenChannels[127] = {"AE", "AG", "AN", "AR", "AT", "AU", "AW",
-                                          "AZ", "BA", "BB", "BD", "BE", "BG", "BH",
-                                          "BM", "BN", "BO", "BR", "BS", "BT", "BY",
-                                          "CH", "CN", "CL", "CO", "CR", "CU", "CV",
-                                          "CY", "CZ", "DE", "DK", "DM", "DO", "EC",
-                                          "EE", "EG", "ES", "FI", "FK", "FR", "GB",
-                                          "GF", "GG", "GI", "GP", "GR", "GT", "HK",
-                                          "HN", "HR", "HT", "HU", "ID", "IE", "IL",
-                                          "IM", "IN", "IS", "IT", "JE", "JM", "JO",
-                                          "KE", "KI", "KR", "KW", "LA", "LB", "LI",
-                                          "LK", "LS", "LT", "LU", "LV", "MA", "MC",
-                                          "MK", "MO", "MQ", "MR", "MT", "MU", "MV",
-                                          "MW", "MX", "MY", "NG", "NI", "NL", "NO",
-                                          "NZ", "OM", "PA", "PE", "PG", "PH", "PK",
-                                          "PL", "PM", "PT", "RE", "RO", "RU", "SA",
-                                          "SE", "SG", "SI", "SK", "SV", "TH", "TJ",
-                                          "TN", "TR", "TT", "TZ", "UA", "UY", "UZ",
-                                          "VA", "VE", "VG", "VN", "YT", "ZA", "ZM",
-                                          "END"};
+    COUNTRY_CODE CountryCodeElevenChannels[12] = {"AS", "CA", "FM", "GU", "KY", "MP", "PR", "TW",
+                                                 "UM", "US", "VI", "END"};
 
-    string CountryCodeFourteenChannels[2] = {"JP", "END" };
+    COUNTRY_CODE CountryCodeThirteenChannels[127] = {"AE", "AG", "AN", "AR", "AT", "AU", "AW",
+                                                    "AZ", "BA", "BB", "BD", "BE", "BG", "BH",
+                                                    "BM", "BN", "BO", "BR", "BS", "BT", "BY",
+                                                    "CH", "CN", "CL", "CO", "CR", "CU", "CV",
+                                                    "CY", "CZ", "DE", "DK", "DM", "DO", "EC",
+                                                    "EE", "EG", "ES", "FI", "FK", "FR", "GB",
+                                                    "GF", "GG", "GI", "GP", "GR", "GT", "HK",
+                                                    "HN", "HR", "HT", "HU", "ID", "IE", "IL",
+                                                    "IM", "IN", "IS", "IT", "JE", "JM", "JO",
+                                                    "KE", "KI", "KR", "KW", "LA", "LB", "LI",
+                                                    "LK", "LS", "LT", "LU", "LV", "MA", "MC",
+                                                    "MK", "MO", "MQ", "MR", "MT", "MU", "MV",
+                                                    "MW", "MX", "MY", "NG", "NI", "NL", "NO",
+                                                    "NZ", "OM", "PA", "PE", "PG", "PH", "PK",
+                                                    "PL", "PM", "PT", "RE", "RO", "RU", "SA",
+                                                    "SE", "SG", "SI", "SK", "SV", "TH", "TJ",
+                                                    "TN", "TR", "TT", "TZ", "UA", "UY", "UZ",
+                                                    "VA", "VE", "VG", "VN", "YT", "ZA", "ZM",
+                                                    "END"};
 };
 
 #endif

--- a/ISM43362/ISM43362.h
+++ b/ISM43362/ISM43362.h
@@ -230,6 +230,7 @@ private:
     volatile int _active_id;
     void print_rx_buff(void);
     bool check_response(void);
+    bool check_country_code(const char* country_code);
     struct packet {
         struct packet *next;
         int id;
@@ -248,6 +249,31 @@ private:
     // Connection state reporting
     nsapi_connection_status_t _conn_status;
     mbed::Callback<void()> _conn_stat_cb;
+
+    string CountryCodeElevenChannels[12] = {"AS", "CA", "FM", "GU", "KY", "MP", "PR", "TW",
+                                        "UM", "US", "VI", "END"};
+
+    string CountryCodeThirteenChannels[127] = {"AE", "AG", "AN", "AR", "AT", "AU", "AW",
+                                          "AZ", "BA", "BB", "BD", "BE", "BG", "BH",
+                                          "BM", "BN", "BO", "BR", "BS", "BT", "BY",
+                                          "CH", "CN", "CL", "CO", "CR", "CU", "CV",
+                                          "CY", "CZ", "DE", "DK", "DM", "DO", "EC",
+                                          "EE", "EG", "ES", "FI", "FK", "FR", "GB",
+                                          "GF", "GG", "GI", "GP", "GR", "GT", "HK",
+                                          "HN", "HR", "HT", "HU", "ID", "IE", "IL",
+                                          "IM", "IN", "IS", "IT", "JE", "JM", "JO",
+                                          "KE", "KI", "KR", "KW", "LA", "LB", "LI",
+                                          "LK", "LS", "LT", "LU", "LV", "MA", "MC",
+                                          "MK", "MO", "MQ", "MR", "MT", "MU", "MV",
+                                          "MW", "MX", "MY", "NG", "NI", "NL", "NO",
+                                          "NZ", "OM", "PA", "PE", "PG", "PH", "PK",
+                                          "PL", "PM", "PT", "RE", "RO", "RU", "SA",
+                                          "SE", "SG", "SI", "SK", "SV", "TH", "TJ",
+                                          "TN", "TR", "TT", "TZ", "UA", "UY", "UZ",
+                                          "VA", "VE", "VG", "VN", "YT", "ZA", "ZM",
+                                          "END"};
+
+    string CountryCodeFourteenChannels[2] = {"JP", "END" };
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Some debug print on console can help to debug if necessary.
 
 Another way to enable these prints is overwrite MBED_CONF_ISM43362_WIFI_DEBUG in your json file:
             "ism43362.wifi-debug": true
+			
+## Options
+
+Country code can be specified by using the "ism43362.wifi-country-code" parameter of mbed_app.json.
+
+The default country code = US (USA)
+
+Link between code and country is here :
+https://www.juniper.net/documentation/en_US/release-independent/junos/topics/reference/specifications/access-point-ax411-country-channel-support.html
+
+Useful to use all the Radio Channels available in a country.
 
 
 ## Firmware version & firmware update

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,6 +1,10 @@
 {
     "name": "ism43362",
     "config": {
+	    "wifi-country_code": {
+            "help": "Country Code to specify cannel number",
+            "value": "\"JP\""
+        },
         "wifi-miso": {
             "help": "SPI-MISO connection to external device",
             "value": "NC"

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,9 +1,8 @@
 {
     "name": "ism43362",
     "config": {
-	    "wifi-country_code": {
-            "help": "Country Code to specify cannel number",
-            "value": "\"JP\""
+	    "wifi-country-code": {
+            "help": "Country Code to specify channel number"
         },
         "wifi-miso": {
             "help": "SPI-MISO connection to external device",


### PR DESCRIPTION
Allow user to modify country code in mbed_app.json file.
For instance : "ism43362.wifi-country_code": ""FR""

Link between code and country is here:
https://www.juniper.net/documentation/en_US/release-independent/junos/topics/reference/specifications/access-point-ax411-country-channel-support.html
The default Country Code = JP (JAPAN)
Useful to use all the Radio Channels available in a country.

WiFi Modem firmware version 3575.

