### PR TITLE
B_L4S5I_IOT01A support

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -76,7 +76,7 @@ ISM43362Interface::ISM43362Interface(bool debug)
         debug_if(_ism_debug, "ISM43362Interface: read_version issue\r\n");
     }
 
-#if TARGET_DISCO_L475VG_IOT01A
+#if !TARGET_DISCO_F413ZH
     if ((int32_t)_FwVersion < ParseNumber((char *)LATEST_FW_VERSION_NUMBER, NULL)) {
         debug_if(_ism_debug, "ISM43362Interface: please update FW\r\n");
     }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ISM43362 module is soldered on the following platforms from STMicroelectronics
 
  * [DISCO_L475VG_IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/)
  * [DISCO_F413ZH](https://os.mbed.com/platforms/ST-Discovery-F413H/)
+ * [B_L4S5I_IOT01A](https://os.mbed.com/platforms/B-L4S5I-IOT01A/)
 
 ## Configuration
 
@@ -53,8 +54,8 @@ Useful to use all the Radio Channels available in a country.
 
 The recommended firmware version is ISM43362-M3G-L44-SPI-C3.5.2.5.STM
 
-The utility to upgrade firmware on B-L475-IOT01A board can be found here: https://www.st.com/resource/en/utilities/inventek_fw_updater.zip
+The utility to upgrade firmware on B-L475-IOT01A and B_L4S5I_IOT01A boards can be found here: https://www.st.com/resource/en/utilities/inventek_fw_updater.zip
 
 It contains instructions and URL where to get firmware from (https://www.inventeksys.com/iwin/firmware/)
 
-Note that only Wifi module from DISCO_L475VG_IOT01A can be updated (HW limitation for DISCO_F413ZH).
+Note that only Wifi module from DISCO_F413ZH cannot be updated (HW limitation).

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -69,6 +69,16 @@
             "ism43362.wifi-dataready": "PE_1",
             "ism43362.wifi-wakeup": "PB_13",
             "ism43362.provide-default": true
+        },
+        "B_L4S5I_IOT01A": {
+            "ism43362.wifi-miso": "PC_11",
+            "ism43362.wifi-mosi": "PC_12",
+            "ism43362.wifi-sclk": "PC_10",
+            "ism43362.wifi-nss": "PE_0",
+            "ism43362.wifi-reset": "PE_8",
+            "ism43362.wifi-dataready": "PE_1",
+            "ism43362.wifi-wakeup": "PB_13",
+            "ism43362.provide-default": true
         }
      }
 }


### PR DESCRIPTION
Hi

B_L4S5I_IOT01A support in mbed-os is on going:
https://github.com/ARMmbed/mbed-os/pull/13542

https://www.st.com/en/evaluation-tools/b-l4s5i-iot01a.html

@ARMmbed/team-st-mcd 
