### PR TITLE
[wifi-ism43362] compilation warnings with chrono 

### DIFF
--- a/ISM43362/ATParser/BufferedSpi/BufferedSpi.cpp
+++ b/ISM43362/ATParser/BufferedSpi/BufferedSpi.cpp
@@ -45,7 +45,7 @@ int BufferedSpi::wait_cmddata_rdy_high(void)
 
     /* wait for dataready = 1 */
     while (dataready.read() == 0) {
-        if (timer.read_ms() > _timeout) {
+        if (chrono::duration_cast<chrono::milliseconds>(timer.elapsed_time()).count() > _timeout) {
             debug_if(local_debug, "ERROR: SPI write timeout\r\n");
             return -1;
         }
@@ -62,7 +62,7 @@ int BufferedSpi::wait_cmddata_rdy_rising_event(void)
     timer.start();
 
     while (_cmddata_rdy_rising_event == 1) {
-        if (timer.read_ms() > _timeout) {
+        if (chrono::duration_cast<chrono::milliseconds>(timer.elapsed_time()).count() > _timeout) {
             _cmddata_rdy_rising_event = 0;
             if (dataready.read() == 1) {
                 debug_if(local_debug, "ERROR: We missed rising event !! (timemout=%d)\r\n", _timeout);

--- a/ISM43362/ISM43362.cpp
+++ b/ISM43362/ISM43362.cpp
@@ -120,7 +120,7 @@ bool ISM43362::reset(void)
     _resetpin = 0;
     wait_us(10000);
     _resetpin = 1;
-    rtos::ThisThread::sleep_for(500);
+    rtos::ThisThread::sleep_for(500ms);
 
     /* Wait for prompt line : the string is "> ". */
     /* As the space char is not detected by sscanf function in parser.recv, */

--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -428,7 +428,7 @@ void ISM43362Interface::socket_check_read()
             }
             _mutex.unlock();
         }
-        rtos::ThisThread::sleep_for(50);
+        rtos::ThisThread::sleep_for(50ms);
     }
 }
 


### PR DESCRIPTION
This commit solves the compilation warnings with chrono library in
mbed-os.

Summary of changes:

        modified:   ISM43362/ATParser/BufferedSpi/BufferedSpi.cpp
        modified:   ISM43362/ISM43362.cpp
        modified:   ISM43362Interface.cpp

Impact of changes:

    No Warnings seen while compiling with mbed-os.

Migration actions required:

Pull request type
[x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)

Test results:

[x] No Tests required for this change (E.g docs only update)
[] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR

Signed-off-by: Kather Rafi Ibrahim <katherrafi.i@hcl.com>